### PR TITLE
Updated Key parsing

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -122,7 +122,7 @@ impl GameState {
                     if e.ctrl_key() {
                         // Block event if a keybind is registered with same key
                         let keybind = Keybind {
-                            key: e.key().try_into().unwrap_or(Key::Zero),
+                            key: Key::try_from_js(e.key()).unwrap_or(Key::Zero),
                             modifier: Some(Key::Control),
                         };
                         if kb_manager.get_action(&keybind).is_some() {
@@ -142,14 +142,14 @@ impl GameState {
                             // Edge-case use code (Digitn or Numpadn) to generate Key object
                             let key_digit = e.code().chars().last().unwrap();
                             if key_digit.is_ascii_digit() {
-                                key = Some(key_digit.to_string().try_into().unwrap());
+                                key = Some(Key::try_from_js(key_digit.to_string()).unwrap());
                             }
                         }
 
                         if key.is_none() {
                             // Edge-case didn't apply, do normal logic with e.key
                             // Map unknown keys to 0 (probably should warn users in console)
-                            key = Some(e.key().try_into().unwrap_or(Key::Zero));
+                            key = Some(Key::try_from_js(e.key()).unwrap_or(Key::Zero));
                         }
                         let key = key.unwrap();
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -60,6 +60,84 @@ pub enum Key {
 }
 
 impl Key {
+    /// Converts from the value of KeyboardEvent.key (see MDN docs)
+    pub fn try_from_js(value: String) -> Result<Self, KeyParseError> {
+        match value.as_ref() {
+            // Match both uppercase & lowercase to same Key value
+            "a" | "A" => Ok(Self::A),
+            "b" | "B" => Ok(Self::B),
+            "c" | "C" => Ok(Self::C),
+            "d" | "D" => Ok(Self::D),
+            "e" | "E" => Ok(Self::E),
+            "f" | "F" => Ok(Self::F),
+            "g" | "G" => Ok(Self::G),
+            "h" | "H" => Ok(Self::H),
+            "i" | "I" => Ok(Self::I),
+            "j" | "J" => Ok(Self::J),
+            "k" | "K" => Ok(Self::K),
+            "l" | "L" => Ok(Self::L),
+            "m" | "M" => Ok(Self::M),
+            "n" | "N" => Ok(Self::N),
+            "o" | "O" => Ok(Self::O),
+            "p" | "P" => Ok(Self::P),
+            "q" | "Q" => Ok(Self::Q),
+            "r" | "R" => Ok(Self::R),
+            "s" | "S" => Ok(Self::S),
+            "t" | "T" => Ok(Self::T),
+            "u" | "U" => Ok(Self::U),
+            "v" | "V" => Ok(Self::V),
+            "w" | "W" => Ok(Self::W),
+            "x" | "X" => Ok(Self::X),
+            "y" | "Y" => Ok(Self::Y),
+            "z" | "Z" => Ok(Self::Z),
+            "0" => Ok(Self::Zero),
+            "1" => Ok(Self::One),
+            "2" => Ok(Self::Two),
+            "3" => Ok(Self::Three),
+            "4" => Ok(Self::Four),
+            "5" => Ok(Self::Five),
+            "6" => Ok(Self::Six),
+            "7" => Ok(Self::Seven),
+            "8" => Ok(Self::Eight),
+            "9" => Ok(Self::Nine),
+            " " => Ok(Self::Space),
+            "ArrowUp" => Ok(Self::ArrowUp),
+            "ArrowDown" => Ok(Self::ArrowDown),
+            "ArrowLeft" => Ok(Self::ArrowLeft),
+            "ArrowRight" => Ok(Self::ArrowRight),
+            "Escape" => Ok(Self::Escape),
+            "Enter" => Ok(Self::Enter),
+            "Backspace" => Ok(Self::Backspace),
+            "Tab" => Ok(Self::Tab),
+            "CapsLock" => Ok(Self::CapsLock),
+            "Shift" => Ok(Self::Shift),
+            "Alt" => Ok(Self::Alt),
+            "Control" => Ok(Self::Control),
+            "Meta" => Ok(Self::Meta),
+            "ContextMenu" => Ok(Self::ContextMenu),
+            _ => Err(KeyParseError::Js(value)),
+        }
+    }
+
+    pub fn try_from_config(value: String) -> Result<Self, KeyParseError> {
+        // Most of the config keys share their name with the JS notation. Only program keys w/
+        // different names, and default to JS names otherwise
+        match value.as_ref() {
+            "Up" => Ok(Self::ArrowUp),
+            "Down" => Ok(Self::ArrowDown),
+            "Left" => Ok(Self::ArrowLeft),
+            "Right" => Ok(Self::ArrowRight),
+            "Space" => Ok(Self::Space),
+            _ => {
+                // Default to JS
+                match Self::try_from_js(value.clone()) {
+                    Ok(k) => Ok(k),
+                    Err(_) => Err(KeyParseError::Config(value)),
+                }
+            }
+        }
+    }
+
     pub fn is_digit(&self) -> bool {
         matches!(
             self,
@@ -106,68 +184,15 @@ impl From<Key> for u8 {
     }
 }
 
-#[derive(Error, Debug)]
+/* #[derive(Error, Debug)]
 #[error("Invalid key value: {0}")]
 pub struct KeyParseError(String);
+*/
 
-impl TryFrom<String> for Key {
-    type Error = KeyParseError;
-
-    /// Converts from the value of KeyboardEvent.key (see MDN docs)
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        match value.as_ref() {
-            "a" | "A" => Ok(Self::A),
-            "b" | "B" => Ok(Self::B),
-            "c" | "C" => Ok(Self::C),
-            "d" | "D" => Ok(Self::D),
-            "e" | "E" => Ok(Self::E),
-            "f" | "F" => Ok(Self::F),
-            "g" | "G" => Ok(Self::G),
-            "h" | "H" => Ok(Self::H),
-            "i" | "I" => Ok(Self::I),
-            "j" | "J" => Ok(Self::J),
-            "k" | "K" => Ok(Self::K),
-            "l" | "L" => Ok(Self::L),
-            "m" | "M" => Ok(Self::M),
-            "n" | "N" => Ok(Self::N),
-            "o" | "O" => Ok(Self::O),
-            "p" | "P" => Ok(Self::P),
-            "q" | "Q" => Ok(Self::Q),
-            "r" | "R" => Ok(Self::R),
-            "s" | "S" => Ok(Self::S),
-            "t" | "T" => Ok(Self::T),
-            "u" | "U" => Ok(Self::U),
-            "v" | "V" => Ok(Self::V),
-            "w" | "W" => Ok(Self::W),
-            "x" | "X" => Ok(Self::X),
-            "y" | "Y" => Ok(Self::Y),
-            "z" | "Z" => Ok(Self::Z),
-            "0" => Ok(Self::Zero),
-            "1" => Ok(Self::One),
-            "2" => Ok(Self::Two),
-            "3" => Ok(Self::Three),
-            "4" => Ok(Self::Four),
-            "5" => Ok(Self::Five),
-            "6" => Ok(Self::Six),
-            "7" => Ok(Self::Seven),
-            "8" => Ok(Self::Eight),
-            "9" => Ok(Self::Nine),
-            " " | "Space" => Ok(Self::Space),
-            "ArrowUp" => Ok(Self::ArrowUp),
-            "ArrowDown" => Ok(Self::ArrowDown),
-            "ArrowLeft" => Ok(Self::ArrowLeft),
-            "ArrowRight" => Ok(Self::ArrowRight),
-            "Escape" => Ok(Self::Escape),
-            "Enter" => Ok(Self::Enter),
-            "Backspace" => Ok(Self::Backspace),
-            "Tab" => Ok(Self::Tab),
-            "CapsLock" => Ok(Self::CapsLock),
-            "Shift" => Ok(Self::Shift),
-            "Alt" => Ok(Self::Alt),
-            "Control" => Ok(Self::Control),
-            "Meta" => Ok(Self::Meta),
-            "ContextMenu" => Ok(Self::ContextMenu),
-            _ => Err(KeyParseError(value)),
-        }
-    }
+#[derive(Error, Debug)]
+pub enum KeyParseError {
+    #[error("Invalid config key notation: {0}")]
+    Config(String),
+    #[error("Invalid config JS notation: {0}")]
+    Js(String),
 }

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -56,7 +56,7 @@ impl TryFrom<String> for Keybind {
         match value.chars().filter(|&c| c == '-').count() {
             0 => {
                 // No modifier keys, whole string should just be the character
-                let key = value.try_into().map_err(KeybindParsingError::Key)?;
+                let key = Key::try_from_config(value).map_err(KeybindParsingError::Key)?;
                 Ok(Keybind {
                     key,
                     modifier: None,
@@ -80,7 +80,7 @@ impl TryFrom<String> for Keybind {
                     _ => return Err(KeybindParsingError::ModifierKey(value)),
                 };
 
-                let key = match key.unwrap().try_into() {
+                let key = match Key::try_from_config(key.unwrap()) {
                     Ok(k) => k,
                     Err(e) => return Err(KeybindParsingError::Key(e)),
                 };


### PR DESCRIPTION
Removed the `From<String>` trait of `Key` and replaced it with 2 constructors: `try_from_js` and `try_from_config`, having the same signature as the From trait. The 2 constructors differentiate the syntax of the `keydown` javascript event and the syntax of the config.